### PR TITLE
Fixed rendering of tiny rectangles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Fixed rendering of tiny rectangles with width or height of 2 or lower [@edward-jazzhands]
+
 ## [0.8.0] - 2025-05-24
 
 ### Changed

--- a/docs/examples/mouse_rectangle_drag.py
+++ b/docs/examples/mouse_rectangle_drag.py
@@ -36,7 +36,6 @@ class MouseDragCanvas(Canvas):
 
 
 class MouseRectangleDragApp(App[None]):
-
     def compose(self) -> ComposeResult:
         yield MouseDragCanvas()
 

--- a/docs/examples/mouse_rectangle_drag.py
+++ b/docs/examples/mouse_rectangle_drag.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+from textual import on, events
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual_hires_canvas import Canvas
+
+
+class CustomCanvas(Canvas):
+
+    @on(Canvas.Resize)
+    def handle_canvas_resize(self, event: Canvas.Resize) -> None:
+        self.reset(size=event.size, refresh=True)
+
+    def clear_canvas(self) -> None:
+        """Clear the canvas."""
+
+        assert self._canvas_size, "Invalid canvas size."
+        width = self._canvas_size.width
+        height = self._canvas_size.height
+        self._buffer = [[" "] * width for _ in range(height)]
+        self._styles = [[""] * width for _ in range(height)]
+        self.refresh()
+
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+
+        if event.button == 1:  # left button
+            self.position_on_down = event.offset
+            self.capture_mouse()
+
+    def on_mouse_up(self) -> None:
+        self.release_mouse()
+        self.clear_canvas()
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+
+        if self.app.mouse_captured == self:
+            self.clear_canvas()
+
+            # Get the absolute position of the mouse right now (event.screen_offset),
+            # minus where it was when the mouse was pressed down (position_on_down).
+            total_delta = event.offset - self.position_on_down
+
+            self.draw_rectangle_box(
+                x0=self.position_on_down.x,
+                y0=self.position_on_down.y,
+                x1=self.position_on_down.x + total_delta.x,
+                y1=self.position_on_down.y + total_delta.y,
+                style="bold cyan",
+            )
+
+class MouseRectangleDragApp(App[None]):
+
+    def compose(self) -> ComposeResult:
+        yield CustomCanvas(id="canvas")
+
+    def on_mount(self) -> None:
+        canvas = self.query_one(CustomCanvas)
+        canvas.reset(size=canvas.size, refresh=True)
+        canvas.clear_canvas()
+
+
+if __name__ == "__main__":
+    MouseRectangleDragApp().run()

--- a/docs/examples/mouse_rectangle_drag.py
+++ b/docs/examples/mouse_rectangle_drag.py
@@ -1,25 +1,14 @@
 from __future__ import annotations
 from textual import on, events
 from textual.app import App, ComposeResult
-from textual.containers import Container
 from textual_hires_canvas import Canvas
 
 
-class CustomCanvas(Canvas):
+class MouseDragCanvas(Canvas):
 
     @on(Canvas.Resize)
     def handle_canvas_resize(self, event: Canvas.Resize) -> None:
         self.reset(size=event.size, refresh=True)
-
-    def clear_canvas(self) -> None:
-        """Clear the canvas."""
-
-        assert self._canvas_size, "Invalid canvas size."
-        width = self._canvas_size.width
-        height = self._canvas_size.height
-        self._buffer = [[" "] * width for _ in range(height)]
-        self._styles = [[""] * width for _ in range(height)]
-        self.refresh()
 
     def on_mouse_down(self, event: events.MouseDown) -> None:
 
@@ -29,12 +18,12 @@ class CustomCanvas(Canvas):
 
     def on_mouse_up(self) -> None:
         self.release_mouse()
-        self.clear_canvas()
+        self.reset()
 
     def on_mouse_move(self, event: events.MouseMove) -> None:
 
         if self.app.mouse_captured == self:
-            self.clear_canvas()
+            self.reset()
 
             # Get the absolute position of the mouse right now (event.screen_offset),
             # minus where it was when the mouse was pressed down (position_on_down).
@@ -51,12 +40,11 @@ class CustomCanvas(Canvas):
 class MouseRectangleDragApp(App[None]):
 
     def compose(self) -> ComposeResult:
-        yield CustomCanvas(id="canvas")
+        yield MouseDragCanvas(id="canvas")
 
     def on_mount(self) -> None:
-        canvas = self.query_one(CustomCanvas)
+        canvas = self.query_one(MouseDragCanvas)
         canvas.reset(size=canvas.size, refresh=True)
-        canvas.clear_canvas()
 
 
 if __name__ == "__main__":

--- a/docs/examples/mouse_rectangle_drag.py
+++ b/docs/examples/mouse_rectangle_drag.py
@@ -5,13 +5,11 @@ from textual_hires_canvas import Canvas
 
 
 class MouseDragCanvas(Canvas):
-
     @on(Canvas.Resize)
     def handle_canvas_resize(self, event: Canvas.Resize) -> None:
         self.reset(size=event.size, refresh=True)
 
     def on_mouse_down(self, event: events.MouseDown) -> None:
-
         if event.button == 1:  # left button
             self.position_on_down = event.offset
             self.capture_mouse()
@@ -21,12 +19,11 @@ class MouseDragCanvas(Canvas):
         self.reset()
 
     def on_mouse_move(self, event: events.MouseMove) -> None:
-
         if self.app.mouse_captured == self:
             self.reset()
 
-            # Get the absolute position of the mouse right now (event.screen_offset),
-            # minus where it was when the mouse was pressed down (position_on_down).
+            # Get the absolute position of the mouse right now (event.offset),
+            # minus where it was when the mouse was pressed down.
             total_delta = event.offset - self.position_on_down
 
             self.draw_rectangle_box(
@@ -37,8 +34,8 @@ class MouseDragCanvas(Canvas):
                 style="bold cyan",
             )
 
-class MouseRectangleDragApp(App[None]):
 
+class MouseRectangleDragApp(App[None]):
     def compose(self) -> ComposeResult:
         yield MouseDragCanvas(id="canvas")
 

--- a/docs/examples/mouse_rectangle_drag.py
+++ b/docs/examples/mouse_rectangle_drag.py
@@ -36,12 +36,9 @@ class MouseDragCanvas(Canvas):
 
 
 class MouseRectangleDragApp(App[None]):
-    def compose(self) -> ComposeResult:
-        yield MouseDragCanvas(id="canvas")
 
-    def on_mount(self) -> None:
-        canvas = self.query_one(MouseDragCanvas)
-        canvas.reset(size=canvas.size, refresh=True)
+    def compose(self) -> ComposeResult:
+        yield MouseDragCanvas()
 
 
 if __name__ == "__main__":

--- a/justfile
+++ b/justfile
@@ -1,6 +1,10 @@
 demo:
     uv run textual run textual_hires_canvas.demo:DemoApp
 
+# Run an example in docs/examples. Usage: just example minimal.py
+example script:
+    uv run docs/examples/{{script}}
+
 typecheck:
     uv run mypy -p textual_hires_canvas --strict
 

--- a/src/textual_hires_canvas/canvas.py
+++ b/src/textual_hires_canvas/canvas.py
@@ -996,7 +996,7 @@ class Canvas(Widget):
             self.set_pixel(x0, y1, char=get_box((T, 0, 0, 0)), style=style)
             return
 
-        # Height is 1, width is greater than 1.
+        # Height is 1, width is greater than 2.
         # Place two horizontal line enders and draw a horizontal line between them.
         if (y1 - y0 == 0) and (x1 - x0 >= 1):
             self.set_pixel(x0, y0, char=get_box((0, T, 0, 0)), style=style)
@@ -1006,7 +1006,7 @@ class Canvas(Widget):
             )
             return
 
-        # Width is 1, height is greater than 1.
+        # Width is 1, height is greater than 2.
         # Place two vertical line enders and draw a vertical line between them.
         if (x1 - x0 == 0) and (y1 - y0 >= 1):
             self.set_pixel(x0, y0, char=get_box((0, 0, T, 0)), style=style)

--- a/src/textual_hires_canvas/canvas.py
+++ b/src/textual_hires_canvas/canvas.py
@@ -972,48 +972,43 @@ class Canvas(Widget):
         #    │            │
         #    │            │
         #    └────────────┘
-        # (x1, y0)     (x1, y1)
+        # (x0, y1)     (x1, y1)
+
+        # NOTE: A difference of 0 between coordinates results in a
+        # width or height of 1 cell inside Textual.
 
         T = thickness
         x0, x1 = sorted((x0, x1))
         y0, y1 = sorted((y0, y1))
 
-        # Both width and height are 1. Show nothing.
-        # Note that a diference of 0 means there's no difference between the points,
-        # meaning the width or height would be 1.
+        # Both width and height are 1. This would just be a dot, so
+        # we don't draw anything.
         if (x1 - x0 == 0) and (y1 - y0 == 0):
             return
-
-        # Height is 1, width is 2. Place two horizontal line enders and return
-        if (y1 - y0 == 0) and (x1 - x0 == 1):
+        
+        # We now know either the width or height must be higher than 2.
+        # Height is 1, place two horizontal line enders.
+        if y1 - y0 == 0:
             self.set_pixel(x0, y0, char=get_box((0, T, 0, 0)), style=style)
             self.set_pixel(x1, y0, char=get_box((0, 0, 0, T)), style=style)
+            if x1 - x0 >= 2:
+                # Width is greater than or equal to 3, draw a horizontal line
+                # between the line enders.
+                self.draw_line(
+                    x0 + 1, y0, x1 - 1, y1, char=get_box((0, T, 0, T)), style=style
+                )
             return
 
-        # Width is 1, height is 2. Place two vertical line enders and return
-        if (x1 - x0 == 0) and (y1 - y0 == 1):
+        # Width is 1, place two vertical line enders.
+        if x1 - x0 == 0:
             self.set_pixel(x0, y0, char=get_box((0, 0, T, 0)), style=style)
             self.set_pixel(x0, y1, char=get_box((T, 0, 0, 0)), style=style)
-            return
-
-        # Height is 1, width is greater than or equal to 2.
-        # Place two horizontal line enders and draw a horizontal line between them.
-        if (y1 - y0 == 0) and (x1 - x0 >= 1):
-            self.set_pixel(x0, y0, char=get_box((0, T, 0, 0)), style=style)
-            self.set_pixel(x1, y0, char=get_box((0, 0, 0, T)), style=style)
-            self.draw_line(
-                x0 + 1, y0, x1 - 1, y1, char=get_box((0, T, 0, T)), style=style
-            )
-            return
-
-        # Width is 1, height is greater than or equal to 2.
-        # Place two vertical line enders and draw a vertical line between them.
-        if (x1 - x0 == 0) and (y1 - y0 >= 1):
-            self.set_pixel(x0, y0, char=get_box((0, 0, T, 0)), style=style)
-            self.set_pixel(x0, y1, char=get_box((T, 0, 0, 0)), style=style)
-            self.draw_line(
-                x0, y0 + 1, x1, y1 - 1, char=get_box((T, 0, T, 0)), style=style
-            )
+            if y1 - y0 >= 2:
+                # Height is greater than or equal to 3, draw a horizontal line
+                # between the line enders.
+                self.draw_line(
+                    x0, y0 + 1, x1, y1 - 1, char=get_box((T, 0, T, 0)), style=style
+                )
             return
 
         # The remaining conditions require all the corner pieces to be drawn.
@@ -1022,37 +1017,22 @@ class Canvas(Widget):
         self.set_pixel(x1, y1, char=get_box((T, 0, 0, T)), style=style)
         self.set_pixel(x0, y1, char=get_box((T, T, 0, 0)), style=style)
 
-        # If width and height are both 2, we don't need any lines. Just return.
+        # If width and height are both 2, we don't need any lines. Only corners.
         if (x1 - x0 == 1) and (y1 - y0 == 1):
             return
 
-        # Width is 2, height is greater than or equal to 3.
-        # Only draw height lines.
-        if (x1 - x0 == 1) and (y1 - y0 >= 2):
-            for x in x0, x1:
-                self.draw_line(
-                    x, y0 + 1, x, y1 - 1, char=get_box((T, 0, T, 0)), style=style
-                )
-            return
-
-        # Height is 2, width is greater than or equal to 3.
-        # Only draw width lines.
-        if (y1 - y0 == 1) and (x1 - x0 >= 2):
+        # Width is greater than or equal to 3, draw horizontal lines.
+        if x1 - x0 >= 2:
             for y in y0, y1:
                 self.draw_line(
                     x0 + 1, y, x1 - 1, y, char=get_box((0, T, 0, T)), style=style
                 )
-            return
-
-        # If both width and height are greater than 2, draw all middle lines.
-        for y in y0, y1:
-            self.draw_line(
-                x0 + 1, y, x1 - 1, y, char=get_box((0, T, 0, T)), style=style
-            )
-        for x in x0, x1:
-            self.draw_line(
-                x, y0 + 1, x, y1 - 1, char=get_box((T, 0, T, 0)), style=style
-            )
+        # Height is greater than or equal to 3, draw vertical lines.
+        if y1 - y0 >= 2:
+            for x in x0, x1:
+                self.draw_line(
+                    x, y0 + 1, x, y1 - 1, char=get_box((T, 0, T, 0)), style=style
+                )
 
     def draw_filled_circle(
         self, cx: int, cy: int, radius: int, style: str = "white"

--- a/src/textual_hires_canvas/canvas.py
+++ b/src/textual_hires_canvas/canvas.py
@@ -996,7 +996,7 @@ class Canvas(Widget):
             self.set_pixel(x0, y1, char=get_box((T, 0, 0, 0)), style=style)
             return
 
-        # Height is 1, width is greater than 2.
+        # Height is 1, width is greater than or equal to 2.
         # Place two horizontal line enders and draw a horizontal line between them.
         if (y1 - y0 == 0) and (x1 - x0 >= 1):
             self.set_pixel(x0, y0, char=get_box((0, T, 0, 0)), style=style)
@@ -1006,7 +1006,7 @@ class Canvas(Widget):
             )
             return
 
-        # Width is 1, height is greater than 2.
+        # Width is 1, height is greater than or equal to 2.
         # Place two vertical line enders and draw a vertical line between them.
         if (x1 - x0 == 0) and (y1 - y0 >= 1):
             self.set_pixel(x0, y0, char=get_box((0, 0, T, 0)), style=style)
@@ -1026,7 +1026,8 @@ class Canvas(Widget):
         if (x1 - x0 == 1) and (y1 - y0 == 1):
             return
 
-        # Width is 2, height is greater than 2. Only draw height lines.
+        # Width is 2, height is greater than or equal to 3.
+        # Only draw height lines.
         if (x1 - x0 == 1) and (y1 - y0 >= 2):
             for x in x0, x1:
                 self.draw_line(
@@ -1034,7 +1035,8 @@ class Canvas(Widget):
                 )
             return
 
-        # Height is 2, width is greater than 2. Only draw width lines.
+        # Height is 2, width is greater than or equal to 3.
+        # Only draw width lines.
         if (y1 - y0 == 1) and (x1 - x0 >= 2):
             for y in y0, y1:
                 self.draw_line(

--- a/src/textual_hires_canvas/canvas.py
+++ b/src/textual_hires_canvas/canvas.py
@@ -987,30 +987,34 @@ class Canvas(Widget):
         # Height is 1, width is 2. Place two horizontal line enders and return
         if (y1 - y0 == 0) and (x1 - x0 == 1):
             self.set_pixel(x0, y0, char=get_box((0, T, 0, 0)), style=style)
-            self.set_pixel(x1, y0, char=get_box((0, 0, 0, T)), style=style)            
+            self.set_pixel(x1, y0, char=get_box((0, 0, 0, T)), style=style)
             return
-        
+
         # Width is 1, height is 2. Place two vertical line enders and return
         if (x1 - x0 == 0) and (y1 - y0 == 1):
             self.set_pixel(x0, y0, char=get_box((0, 0, T, 0)), style=style)
             self.set_pixel(x0, y1, char=get_box((T, 0, 0, 0)), style=style)
-            return 
+            return
 
         # Height is 1, width is greater than 1.
         # Place two horizontal line enders and draw a horizontal line between them.
         if (y1 - y0 == 0) and (x1 - x0 >= 1):
             self.set_pixel(x0, y0, char=get_box((0, T, 0, 0)), style=style)
-            self.set_pixel(x1, y0, char=get_box((0, 0, 0, T)), style=style)            
-            self.draw_line(x0 + 1, y0, x1 - 1, y1, char=get_box((0, T, 0, T)), style=style)
+            self.set_pixel(x1, y0, char=get_box((0, 0, 0, T)), style=style)
+            self.draw_line(
+                x0 + 1, y0, x1 - 1, y1, char=get_box((0, T, 0, T)), style=style
+            )
             return
-        
+
         # Width is 1, height is greater than 1.
         # Place two vertical line enders and draw a vertical line between them.
         if (x1 - x0 == 0) and (y1 - y0 >= 1):
             self.set_pixel(x0, y0, char=get_box((0, 0, T, 0)), style=style)
             self.set_pixel(x0, y1, char=get_box((T, 0, 0, 0)), style=style)
-            self.draw_line(x0, y0 + 1, x1, y1 - 1, char=get_box((T, 0, T, 0)), style=style)
-            return        
+            self.draw_line(
+                x0, y0 + 1, x1, y1 - 1, char=get_box((T, 0, T, 0)), style=style
+            )
+            return
 
         # The remaining conditions require all the corner pieces to be drawn.
         self.set_pixel(x0, y0, char=get_box((0, T, T, 0)), style=style)
@@ -1029,7 +1033,7 @@ class Canvas(Widget):
                     x, y0 + 1, x, y1 - 1, char=get_box((T, 0, T, 0)), style=style
                 )
             return
-            
+
         # Height is 2, width is greater than 2. Only draw width lines.
         if (y1 - y0 == 1) and (x1 - x0 >= 2):
             for y in y0, y1:


### PR DESCRIPTION
Hey there, I implemented the fix and I believe its working perfectly!

I had to make the function significantly longer to handle all the different scenarios. Once I got into it, I realized that I actually needed a few more than 3 simple rules to make it absolutely perfect. This was because of the "line ender" pieces. To make it look 100% perfect, I couldn't just draw a line when width or height is 1 - it needed to be a line with 2 line ender pieces on either side. This made it match up perfectly with the box size. I'm very happy with the result.

The way I went about doing the logic is by having the function return after each condition. I figured that was appropriate here since the Rectangle seems to have way more conditions to run through than other shapes do. But you may want to refactor it to be more like your coding style.

I also added a new example script in docs/examples called `mouse_rectangle_drag.py` so you can try it out yourself easily. As well as making a small addition to the justfile to make it easier to run example scripts.

Let me know if you need any changes, happy to fix things up.